### PR TITLE
Fractal: parallelize fractal generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ BIN := bin
 
 # Compile Vars
 CC := clang
-CFLAGS := -I$(INCLUDE) -Wall -Wextra -Werror
-LDFLAGS :=
+CFLAGS := -I$(INCLUDE) -Wall -Wextra -Werror -fopenmp
+LDFLAGS := -lomp -L/lib/llvm-14/lib
 TARGET := $(BIN)/fractal
 
 all: clean $(TARGET)
@@ -28,7 +28,7 @@ clean:
 	rm -f bmp.o main.o fractal.o $(TARGET)
 
 run: all
-	./$(TARGET)
+	time ./$(TARGET)
 
 tidy: clean
 	mv *.bmp pics/

--- a/src/bmp.c
+++ b/src/bmp.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <omp.h>
 
 #include "bmp.h"
 

--- a/src/fractal.c
+++ b/src/fractal.c
@@ -13,6 +13,8 @@ void set_mandelbot(int world_x, int world_y, char *rgb, struct world_coordinates
     // Number of iterations to perform on n
     const int iterations = 255;
 
+    // Parallelise the outer for loop
+    #pragma omp parallel for
     // Mandelbrot function variables f(z) = z^2 + c
     for (int row = 0; row < world_y; row++){
         double cy = world.set_down + row * pixel_height;

--- a/src/main.c
+++ b/src/main.c
@@ -19,10 +19,10 @@ int main() {
 	
 	struct world_coordinates world;
 
-	world.set_left = -2.5;
-    world.set_right = 1.5;
-    world.set_down = -2.0;
-    world.set_up = 2.0;
+	world.set_left = -0.864;
+    world.set_right = -0.860;
+    world.set_down = 0.230;
+    world.set_up = 0.234;
 
 	set_mandelbot(h, w, bmp, world);
 	write_bmp("test.bmp", bmp, datasize, w);


### PR DESCRIPTION
The fractal is currently executed by a single thread which takes a long time. It can take up to several minutes to generate a zoomed in frame of the Mandelbrot set. OpenMP will allow to easily parallelize it.

Parallelize fractal generation using OpenMP.